### PR TITLE
Clean up Azure CLI installation steps in workflow

### DIFF
--- a/.github/workflows/cycle-stable-testing.yml
+++ b/.github/workflows/cycle-stable-testing.yml
@@ -59,54 +59,6 @@ jobs:
         
       - name: Show Runner Workspace
         run: echo "The workspace of the runner is ${{ runner.workspace }}"
-      
-      # - name: Install Azure CLI if not installed
-      #   shell: powershell
-      #   run: |
-      #     $azDir = "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin"
-      
-      #     if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
-      #       Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile AzureCLI.msi
-      #       Start-Process msiexec.exe -ArgumentList "/I AzureCLI.msi /quiet /norestart" -NoNewWindow -Wait
-      
-      #       if (-not (Test-Path $azDir)) { throw "Expected az directory not found: $azDir" }
-      #     }
-      
-      #     # Make az available to subsequent steps
-      #     $azDir | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-      
-      #     # Also update current step
-      #     $env:Path = "$azDir;$env:Path"
-      
-      #     az --version
-
-      - name: Debug Azure CLI presence
-        shell: powershell
-        run: |
-          Write-Host "Runner: $env:COMPUTERNAME"
-          Write-Host "User: $env:USERNAME"
-          Write-Host "ProgramFiles(x86): ${env:ProgramFiles(x86)}"
-          Write-Host "PATH (first 10):"
-          ($env:Path -split ';' | Select-Object -First 10) | ForEach-Object { "  $_" }
-      
-          Write-Host "`nChecking expected Azure CLI locations..."
-          $candidates = @(
-            "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az.cmd",
-            "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az.exe",
-            "C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\az.cmd",
-            "C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\az.exe"
-          )
-      
-          foreach ($p in $candidates) {
-            if (Test-Path $p) { Write-Host "FOUND: $p" } else { Write-Host "MISS : $p" }
-          }
-      
-          Write-Host "`nTry locate via where.exe:"
-          where.exe az
-      
-          Write-Host "`nSearch disk for az.cmd (can take a bit):"
-          Get-ChildItem "C:\Program Files*" -Recurse -Filter "az.cmd" -ErrorAction SilentlyContinue |
-            Select-Object -First 20 FullName | ForEach-Object { Write-Host $_ }
 
       - &ensure-az
         name: Ensure Azure CLI on PATH
@@ -166,12 +118,6 @@ jobs:
           Get-ChildItem Env: | Where-Object { $_.Name -match '^(PW_|UN_|CS_)' } | ForEach-Object {
             Write-Output " - $($_.Name)"
           }
-
-      - name: Install Chrome, Edge, and drivers
-        shell: powershell
-        run: |
-          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-          .\install-browsers.ps1 -ForceDrivers -ForceBrowsers
           
       - name: Who is my GitHub Actions Runner service running as?
         run: |


### PR DESCRIPTION
Removed commented-out code for Azure CLI installation and debugging.

Moved all Azure CLI steps into our Packer build. Removing all time, adding checks now that I've validated it works.